### PR TITLE
Generalize shop support for container-backed inventories

### DIFF
--- a/src/main/java/savage/commoneconomy/mixin/ContainerBlockEntityMixin.java
+++ b/src/main/java/savage/commoneconomy/mixin/ContainerBlockEntityMixin.java
@@ -1,8 +1,7 @@
 package savage.commoneconomy.mixin;
-
+import net.minecraft.world.Container;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.entity.ChestBlockEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -15,12 +14,12 @@ import savage.commoneconomy.shop.ShopManager;
  * Marks the shop as dirty so its sign gets updated on the next tick cycle.
  */
 @Mixin(BlockEntity.class)
-public abstract class ChestBlockEntityMixin {
+public abstract class ContainerBlockEntityMixin {
 
     @Inject(method = "setChanged", at = @At("TAIL"))
     private void onSetChanged(CallbackInfo ci) {
         BlockEntity self = (BlockEntity) (Object) this;
-        if (self instanceof ChestBlockEntity && self.getLevel() != null && !self.getLevel().isClientSide()) {
+        if (self instanceof Container && self.getLevel() != null && !self.getLevel().isClientSide()) {
             BlockPos pos = self.getBlockPos();
             if (ShopManager.getInstance().isShopChest(pos)) {
                 ShopManager.getInstance().markDirty(pos);

--- a/src/main/java/savage/commoneconomy/shop/ShopInteractionManager.java
+++ b/src/main/java/savage/commoneconomy/shop/ShopInteractionManager.java
@@ -8,11 +8,13 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.WallSignBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import savage.commoneconomy.EconomyManager;
 
 import java.util.HashMap;
@@ -217,7 +219,8 @@ public class ShopInteractionManager {
                     for (Shop shop : ShopManager.getInstance().getAllShops()) {
                         if (worldId.equals(shop.getWorldId())) {
                             BlockPos chestPos = shop.getChestLocation();
-                            if (!(world.getBlockState(chestPos).getBlock() instanceof net.minecraft.world.level.block.ChestBlock)) {
+                            BlockEntity be = world.getBlockEntity(chestPos);
+                            if (!(be instanceof Container)) {
                                 toRemove.add(chestPos);
                             }
                         }

--- a/src/main/resources/savs-common-economy.mixins.json
+++ b/src/main/resources/savs-common-economy.mixins.json
@@ -3,7 +3,7 @@
 	"package": "savage.commoneconomy.mixin",
 	"compatibilityLevel": "JAVA_25",
 	"mixins": [
-		"ChestBlockEntityMixin"
+		"ContainerBlockEntityMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
Previously, shops could be created using any container, but only chests were fully supported internally. As a result, non-chest container shops could be considered orphaned during cleanup and their signs would not update when their inventory changed.

Changes:
- Replace ChestBlockEntity-specific dirty tracking with generic Container support
- Update orphan detection to validate supported containers instead of only chests
- Ensure inventory changes in supported containers trigger shop sign updates

This removes chest-specific assumptions from the shop system and enables proper support for all compatible container block entities.


Note: I don't really know if you actually intend on letting players use any container as a shop or not, but if you do, feel free to merge this pull request. as always, tnx for the awesome mod!